### PR TITLE
ListParamType can now get builtin types in constructor

### DIFF
--- a/click_params/base.py
+++ b/click_params/base.py
@@ -83,12 +83,16 @@ class RangeParamType(CustomParamType):
 
 class ListParamType(CustomParamType):
 
-    def __init__(self, param_type: click.ParamType, separator: str = ',', name: str = None):
+    def __init__(self, param_type: Union[click.ParamType, type], separator: str = ',', name: str = None):
         if not isinstance(separator, str):
             raise TypeError('separator must be a string')
         self._separator = separator
         self._name = name or self.name
-        self._param_type = param_type
+        self._param_type = (
+            param_type
+            if isinstance(param_type, click.ParamType)
+            else click.types.convert_type(param_type)
+        )
         self._error_message = 'These items are not %s: {errors}' % self._name
 
     def _strip_separator(self, expression: str) -> str:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,4 @@
+import fractions
 from fractions import Fraction
 
 import click
@@ -159,7 +160,9 @@ class TestListParamType:
 
     @pytest.mark.parametrize(('expression', 'param_type', 'name', 'errors'), [
         ('1,foo,2', click.INT, 'integers', ['foo']),
+        ('1,foo,2', int, 'integers', ['foo']),
         ('1.4,bar,2.8', click.FLOAT, 'floating point values', ['bar']),
+        ('1.4,bar,2.8', float, 'floating point values', ['bar']),
         ('1,.2,foo', DECIMAL, 'decimal values', ['foo']),
         ('2,1/0', FRACTION, 'fraction values', ['1/0']),
     ])
@@ -173,9 +176,11 @@ class TestListParamType:
 
     @pytest.mark.parametrize(('expression', 'param_type', 'name', 'values'), [
         ('1,2,3', click.INT, 'integers', [1, 2, 3]),
+        ('1,2,3', int, 'integers', [1, 2, 3]),
         ('1,2.5', click.FLOAT, 'floating point values', [1.0, 2.5]),
+        ('1,2.5', float, 'floating point values', [1.0, 2.5]),
         ('2', FRACTION, 'fraction values', [Fraction(2, 1)]),
-        ('5,1.4,2+1j', COMPLEX, 'complex values', [complex(5, 0), complex(1.4, 0), complex(2, 1)])
+        ('5,1.4,2+1j', COMPLEX, 'complex values', [complex(5, 0), complex(1.4, 0), complex(2, 1)]),
     ])
     def test_should_return_correct_items_when_giving_correct_expression(self, expression, param_type, name, values):
         # noinspection PyTypeChecker


### PR DESCRIPTION
Description
========

One of the things that are quite nice about `click` is that it can handle builtin types quite easy.
Now, `ListParamType` can get builtin types in its constructor and convert them into `click.ParamType` without any problems.