### PR TITLE
Add union type to base types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ,'windows-latest' ]
-        python: [ pypy3, 3.6, 3.7, 3.8, 3.9 ]
+        python: [ pypy-3.7, 3.6, 3.7, 3.8, 3.9, '3.10' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/click_params/__init__.py
+++ b/click_params/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '0.1.2'
 
-from .base import BaseParamType, ValidatorParamType, RangeParamType, ListParamType
+from .base import BaseParamType, ValidatorParamType, RangeParamType, ListParamType, UnionParamType
 from .domain import (
     DOMAIN, PUBLIC_URL, URL, EMAIL, SLUG, EmailParamType, DomainListParamType, PublicUrlListParamType,
     UrlListParamType, EmailListParamType, SlugListParamType
@@ -21,7 +21,7 @@ from .test_utils import assert_list_in_output, assert_equals_output, assert_in_o
 
 __all__ = [
     # base
-    'BaseParamType', 'ValidatorParamType', 'RangeParamType', 'ListParamType',
+    'BaseParamType', 'ValidatorParamType', 'RangeParamType', 'ListParamType', "UnionParamType",
 
     # domain
     'DOMAIN', 'PUBLIC_URL', 'URL', 'EmailParamType', 'EMAIL', 'SLUG', 'DomainListParamType', 'PublicUrlListParamType',

--- a/click_params/base.py
+++ b/click_params/base.py
@@ -1,5 +1,5 @@
 """Base classes to implement various parameter types"""
-from typing import Union, Tuple, Callable, List, Any, Optional
+from typing import Union, Tuple, Callable, List, Any, Optional, Sequence
 
 import click
 
@@ -117,6 +117,25 @@ class ListParamType(CustomParamType):
             self.fail(self._error_message.format(errors=errors), param, ctx)
 
         return converted_list
+
+    def __repr__(self):
+        return self.name.upper()
+
+
+class UnionParamType(CustomParamType):
+
+    def __init__(self, param_types: Sequence[click.ParamType], name: str = None):
+        self._name = name or self.name
+        self._param_types = param_types
+        self._error_message = '{value} is not a valid %s' % self._name
+
+    def convert(self, value, param, ctx):
+        for param_type in self._param_types:
+            try:
+                return param_type.convert(value, param, ctx)
+            except click.BadParameter:
+                continue
+        self.fail(self._error_message.format(value=value))
 
     def __repr__(self):
         return self.name.upper()

--- a/docs/usage/miscellaneous.md
+++ b/docs/usage/miscellaneous.md
@@ -177,3 +177,41 @@ has a whitespace, therefore the separator helps to split properly.
 - In the last example the datetime `2019/01/01` fails because the format `%Y/%m/%d` is not one of the defaults used by
 `click.DateTime`. If you want this datetime to be accepted, you need to provide a `formats` argument with the appropriate
 formats.
+
+## UnionParamType
+
+Signature: `UnionParamType(param_types: Sequence[click.ParamType], name: str = None)`
+
+Allows a parameter to accept two kinds of types. This is helpful when an argument or an option should be
+able to accept more than one type.
+
+````python
+import click
+from click_params import UnionParamType
+
+@click.command()
+@click.option('-j', '--jobs', type=UnionParamType([click.Choice(['half', 'all']), click.INT], name="cores number"))
+def cli(jobs):
+    click.echo('Running on {jobs} cores!'.format(jobs=jobs))
+    ...
+````
+
+````bash
+$ python cli.py -j 5
+Running on 5 cores
+
+$ python cli.py -j all
+Running on all cores
+
+$ python cli.py -j 2.5
+Error: 2.5 is not a valid cores number
+
+$ python cli.py -j third
+Error: third is not a valid cores number
+````
+
+Two remarks compared to the last script.
+
+- The order of parameter types in the union is the order click will try to parse the value.
+- In the last two examples click was unable to parse because they were neither an integer or a string from allowed 
+choices

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 
-PYTHON_VERSIONS = ['pypy3', '3.6', '3.7', '3.8', '3.9', 'pypy3']
+PYTHON_VERSIONS = ['pypy3', '3.6', '3.7', '3.8', '3.9', '3.10']
 CI_ENVIRONMENT = 'GITHUB_ACTIONS' in os.environ
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -188,13 +188,13 @@ class TestUnionParamType:
 
     @pytest.mark.parametrize(('expression', 'param_types', 'value'), [
         ('12', (click.INT,), 12),
-        ('auto', (click.Choice(["auto", "full"]), click.INT), "auto"),
-        ('full', (click.Choice(["auto", "full"]), click.INT), "full"),
-        ('12', (click.Choice(["auto", "full"]), click.INT), 12),
-        ('auto', (click.Choice(["auto", "full"]), click.INT, click.FLOAT), "auto"),
-        ('full', (click.Choice(["auto", "full"]), click.INT, click.FLOAT), "full"),
-        ('12', (click.Choice(["auto", "full"]), click.INT, click.FLOAT), 12),
-        ('12.3', (click.Choice(["auto", "full"]), click.INT, click.FLOAT), 12.3)
+        ('auto', (click.Choice(['auto', 'full']), click.INT), 'auto'),
+        ('full', (click.Choice(['auto', 'full']), click.INT), 'full'),
+        ('12', (click.Choice(['auto', 'full']), click.INT), 12),
+        ('auto', (click.Choice(['auto', 'full']), click.INT, click.FLOAT), 'auto'),
+        ('full', (click.Choice(['auto', 'full']), click.INT, click.FLOAT), 'full'),
+        ('12', (click.Choice(['auto', 'full']), click.INT, click.FLOAT), 12),
+        ('12.3', (click.Choice(['auto', 'full']), click.INT, click.FLOAT), 12.3)
     ])
     def test_parse_expression_successfully(self, expression, param_types, value):
         union_type = UnionParamType(param_types=param_types)
@@ -204,8 +204,8 @@ class TestUnionParamType:
 
     @pytest.mark.parametrize(('expression', 'param_types'), [
         ('auto', (click.INT,)),
-        ('12.6', (click.Choice(["auto", "full"]), click.INT)),
-        ('bla', (click.Choice(["auto", "full"]), click.INT, click.FLOAT)),
+        ('12.6', (click.Choice(['auto', 'full']), click.INT)),
+        ('bla', (click.Choice(['auto', 'full']), click.INT, click.FLOAT)),
     ])
     def test_parse_expression_unsuccessfully(self, expression, param_types):
         union_type = UnionParamType(param_types=param_types)


### PR DESCRIPTION
Description
=======

More than once you want an argument or an option to be able to get multiple types of variables.
I implemented this ability in the following PR.

Pay attention that the order of param types should matter -- click_params should try to parse the flag according to the order of the components of `click_params.UnionParamType`. So when having `click_params.UnionParamType(click.INT, click.FLOAT)`, click_params would try to parse **int first and then float**.

Usage Example
==========

The most common example I can think of is when you need an argument to be able to get both numbers and strings.

For example, let us think about a CLI that can run on multiple cores. You might want to specify how many cores to run the CLI on.
So, we add a -j flag that excepts integers to specify the number of cores to run.

Now, one might want to tell the CLI to run on all of the cores or half of the cores. One might do that as follows

```python
import click
import click_params

@click.command()
@click.option('-j', '--jobs', type=click_params.UnionParamType(click.INT, click.Choice(["all", "half"])))
def run_cli(jobs):
    ...
    # Run on cores as stated
```