### PR TITLE
Support enum param type

### DIFF
--- a/click_params/__init__.py
+++ b/click_params/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '0.2.0'
 
-from .base import BaseParamType, ValidatorParamType, RangeParamType, ListParamType, UnionParamType
+from .base import BaseParamType, ValidatorParamType, RangeParamType, ListParamType, UnionParamType, EnumParamType
 from .domain import (
     DOMAIN, PUBLIC_URL, URL, EMAIL, SLUG, EmailParamType, DomainListParamType, PublicUrlListParamType,
     UrlListParamType, EmailListParamType, SlugListParamType
@@ -21,7 +21,7 @@ from .test_utils import assert_list_in_output, assert_equals_output, assert_in_o
 
 __all__ = [
     # base
-    'BaseParamType', 'ValidatorParamType', 'RangeParamType', 'ListParamType', 'UnionParamType',
+    'BaseParamType', 'ValidatorParamType', 'RangeParamType', 'ListParamType', 'UnionParamType', 'EnumParamType',
 
     # domain
     'DOMAIN', 'PUBLIC_URL', 'URL', 'EmailParamType', 'EMAIL', 'SLUG', 'DomainListParamType', 'PublicUrlListParamType',

--- a/docs/usage/miscellaneous.md
+++ b/docs/usage/miscellaneous.md
@@ -214,3 +214,41 @@ Two remarks compared to the last script.
 - The order of parameter types in the union is the order click will try to parse the value.
 - In the last two examples click was unable to parse because they were neither an integer nor a string from allowed 
 choices.
+
+## EnumParamType
+
+Signature: `EnumParamType(enum_type: Type[enum.Enum], transform_upper: bool = True)`
+
+Converts string to an enum value. if `transform_upper` is set to be true, convert name
+to uppercase before getting the enum value.
+
+````python
+import enum
+import click
+from click_params import EnumParamType
+
+
+class MyEnum(enum.Enum):
+
+    ONE = "one"
+    TWO = "two"
+    THREE = "three"
+    ONE_ALIAS = ONE
+
+
+@click.command()
+@click.option("-c", "--choice", type=EnumParamType(MyEnum))
+def f(choice):
+    click.echo("You have chosen {choice}".format(choice=choice))
+````
+
+````bash
+$ python cli.py -c one
+You have chosen MyEnum.ONE
+
+$ python cli.py -c three
+You have chosen MyEnum.Three
+
+$ python cli.py -c unreal
+Error: Unknown MyEnum value: UNREAL
+````


### PR DESCRIPTION
Description
========

Added a new ability to be able to create a choice parameter type from enum class.

Why not using `click.Choice`?
===================

`click.Choice` always returns a string and can't be modified to into any other type. if you try to do that using the `callback` parameter, it will fail.

On the other hand, enums are the way of python to allow only a finite number of values to be accepted in a given scenario. It seems to me like to logical step that `click.Choice` should have returned an enum.

Now, using `EnumParamType`, one can create a choice-like parameter that returns an enum instead of a string.
Moreover, once you add a new value to your enum class, it will automatically update as a valid choice for the paramater type.