### PR TITLE
Ignore empty string in list param type

### DIFF
--- a/click_params/base.py
+++ b/click_params/base.py
@@ -83,7 +83,13 @@ class RangeParamType(CustomParamType):
 
 class ListParamType(CustomParamType):
 
-    def __init__(self, param_type: click.ParamType, separator: str = ',', name: str = None):
+    def __init__(
+        self,
+        param_type: click.ParamType,
+        separator: str = ',',
+        name: str = None,
+        ignore_empty: bool = False
+    ):
         if not isinstance(separator, str):
             raise TypeError('separator must be a string')
         self._separator = separator
@@ -91,6 +97,7 @@ class ListParamType(CustomParamType):
         self._param_type = param_type
         self._convert_called = False
         self._error_message = 'These items are not %s: {errors}' % self._name
+        self._ignore_empty = ignore_empty
 
     def _strip_separator(self, expression: str) -> str:
         """Returns a new expression with heading and trailing separator character removed."""
@@ -118,6 +125,8 @@ class ListParamType(CustomParamType):
         if self._convert_called:
             return value
 
+        if self._ignore_empty and value == "":
+            return []
         value = self._strip_separator(value)
         errors, converted_list = self._convert_expression_to_list(value)
         if errors:

--- a/click_params/domain.py
+++ b/click_params/domain.py
@@ -17,8 +17,8 @@ class DomainParamType(ValidatorParamType):
 class DomainListParamType(ListParamType):
     name = 'domain name list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(DOMAIN, separator=separator, name='domain names')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(DOMAIN, separator=separator, name='domain names', ignore_empty=ignore_empty)
 
 
 class UrlParamType(ValidatorParamType):
@@ -31,15 +31,15 @@ class UrlParamType(ValidatorParamType):
 class UrlListParamType(ListParamType):
     name = 'url list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(URL, separator=separator, name='urls')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(URL, separator=separator, name='urls', ignore_empty=ignore_empty)
 
 
 class PublicUrlListParamType(ListParamType):
     name = 'url list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(PUBLIC_URL, separator=separator, name='urls')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(PUBLIC_URL, separator=separator, name='urls', ignore_empty=ignore_empty)
 
 
 class EmailParamType(ValidatorParamType):
@@ -52,8 +52,8 @@ class EmailParamType(ValidatorParamType):
 class EmailListParamType(ListParamType):
     name = 'email address list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(EMAIL, separator=separator, name='email addresses')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(EMAIL, separator=separator, name='email addresses', ignore_empty=ignore_empty)
 
 
 class SlugParamType(ValidatorParamType):
@@ -66,8 +66,8 @@ class SlugParamType(ValidatorParamType):
 class SlugListParamType(ListParamType):
     name = 'slug list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(SLUG, separator=separator, name='slugs')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(SLUG, separator=separator, name='slugs', ignore_empty=ignore_empty)
 
 
 DOMAIN = DomainParamType()

--- a/click_params/miscellaneous.py
+++ b/click_params/miscellaneous.py
@@ -44,29 +44,31 @@ class MacAddressParamType(ValidatorParamType):
 class MacAddressListParamType(ListParamType):
     name = 'mac address list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(MAC_ADDRESS, separator=separator, name='mac addresses')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(MAC_ADDRESS, separator=separator, name='mac addresses', ignore_empty=ignore_empty)
 
 
 class StringListParamType(ListParamType):
     name = 'string list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(click.STRING, separator)
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(click.STRING, separator, ignore_empty=ignore_empty)
 
 
 class UUIDListParamType(ListParamType):
     name = 'uuid list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(click.UUID, separator=separator, name='uuid')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(click.UUID, separator=separator, name='uuid', ignore_empty=ignore_empty)
 
 
 class DateTimeListParamType(ListParamType):
     name = 'datetime list'
 
-    def __init__(self, separator: str = ',', formats: List[str] = None):
-        super().__init__(click.DateTime(formats=formats), separator=separator, name='datetimes')
+    def __init__(self, separator: str = ',', formats: List[str] = None, ignore_empty: bool = False):
+        super().__init__(
+            click.DateTime(formats=formats), separator=separator, name='datetimes', ignore_empty=ignore_empty
+        )
 
 
 class UnionParamType(CustomParamType):

--- a/click_params/network.py
+++ b/click_params/network.py
@@ -14,8 +14,8 @@ class IpAddress(BaseParamType):
 class IpAddressListParamType(ListParamType):
     name = 'ip address list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(IP_ADDRESS, separator=separator, name='ip addresses')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(IP_ADDRESS, separator=separator, name='ip addresses', ignore_empty=ignore_empty)
 
 
 class Ipv4Address(BaseParamType):
@@ -39,8 +39,8 @@ class Ipv4AddressRange(RangeParamType):
 class Ipv4AddressListParamType(ListParamType):
     name = 'ipv4 address list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(IPV4_ADDRESS, separator=separator, name='ipv4 addresses')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(IPV4_ADDRESS, separator=separator, name='ipv4 addresses', ignore_empty=ignore_empty)
 
 
 class Ipv6Address(BaseParamType):
@@ -64,8 +64,8 @@ class Ipv6AddressRange(RangeParamType):
 class Ipv6AddressListParamType(ListParamType):
     name = 'ipv6 address list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(IPV6_ADDRESS, separator=separator, name='ipv6 addresses')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(IPV6_ADDRESS, separator=separator, name='ipv6 addresses', ignore_empty=ignore_empty)
 
 
 class IpNetwork(BaseParamType):
@@ -78,8 +78,8 @@ class IpNetwork(BaseParamType):
 class IpNetworkListParamType(ListParamType):
     name = 'ip network list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(IP_NETWORK, separator=separator, name='ip networks')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(IP_NETWORK, separator=separator, name='ip networks', ignore_empty=ignore_empty)
 
 
 class Ipv4Network(BaseParamType):
@@ -92,8 +92,8 @@ class Ipv4Network(BaseParamType):
 class Ipv4NetworkListParamType(ListParamType):
     name = 'ipv4 network list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(IPV4_NETWORK, separator=separator, name='ipv4 networks')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(IPV4_NETWORK, separator=separator, name='ipv4 networks', ignore_empty=ignore_empty)
 
 
 class Ipv6Network(BaseParamType):
@@ -106,8 +106,8 @@ class Ipv6Network(BaseParamType):
 class Ipv6NetworkListParamType(ListParamType):
     name = 'ipv6 network list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(IPV6_NETWORK, separator=separator, name='ipv6 networks')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(IPV6_NETWORK, separator=separator, name='ipv6 networks', ignore_empty=ignore_empty)
 
 
 IP_ADDRESS = IpAddress()

--- a/click_params/numeric.py
+++ b/click_params/numeric.py
@@ -24,8 +24,8 @@ class DecimalRange(RangeParamType):
 class DecimalListParamType(ListParamType):
     name = 'decimal list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(DECIMAL, separator=separator, name='decimal values')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(DECIMAL, separator=separator, name='decimal values', ignore_empty=ignore_empty)
 
 
 class FractionParamType(BaseParamType):
@@ -45,8 +45,8 @@ class FractionRange(RangeParamType):
 class FractionListParamType(ListParamType):
     name = 'fraction list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(FRACTION, separator=separator, name='fractions')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(FRACTION, separator=separator, name='fractions', ignore_empty=ignore_empty)
 
 
 class ComplexParamType(BaseParamType):
@@ -59,22 +59,28 @@ class ComplexParamType(BaseParamType):
 class ComplexListParamType(ListParamType):
     name = 'complex list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(COMPLEX, separator=separator, name='complex values')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(
+            COMPLEX, separator=separator, name='complex values', ignore_empty=ignore_empty
+        )
 
 
 class IntListParamType(ListParamType):
     name = 'int list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(click.INT, separator=separator, name='integers')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(
+            click.INT, separator=separator, name='integers', ignore_empty=ignore_empty
+        )
 
 
 class FloatListParamType(ListParamType):
     name = 'float list'
 
-    def __init__(self, separator: str = ','):
-        super().__init__(click.FLOAT, separator=separator, name='floating point values')
+    def __init__(self, separator: str = ',', ignore_empty: bool = False):
+        super().__init__(
+            click.FLOAT, separator=separator, name='floating point values', ignore_empty=ignore_empty
+        )
 
 
 DECIMAL = DecimalParamType()

--- a/docs/api.md
+++ b/docs/api.md
@@ -121,6 +121,8 @@ Parameters:
 - `separator`: the string used to delimit each item of the string.
 - `name`: the name used in the error message to specify the type of the parameter, if it is not provided, the `name`
 class attribute will be used instead.
+- `ignore_empty`: when this flag is True, will treat empty strings as empty lists. This is useful when we want empty
+list to be our default value.
 
 Below is the implementation of the `IntListParamType`.
 

--- a/docs/usage/domain.md
+++ b/docs/usage/domain.md
@@ -42,7 +42,7 @@ Error: hello is not a valid domain name
 
 ## DomainListParamType
 
-Signature: `DomainListParamType(separator: str = ',')`
+Signature: `DomainListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Validates and returns a list of domain names.
 
@@ -100,7 +100,7 @@ Error: hello is not a valid public url
 
 ## PublicUrlListParamType
 
-Signature: `PublicUrlListParamType(separator: str = ',')`
+Signature: `PublicUrlListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Validates and returns a list of public urls.
 
@@ -150,7 +150,7 @@ Error: hello is not a valid public url
 
 ## UrlListParamType
 
-Signature: `UrlListParamType(separator: str = ',')`
+Signature: `UrlListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 It is like [PublicUrlListParamType](#publicurllistparamtype) but accepts private ip addresses.
 
@@ -205,7 +205,7 @@ Error: roo@foo is not a valid email address
 
 ## EmailListParamType
 
-Signature: `EmailListParamType(separator: str = ',')`
+Signature: `EmailListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Validates and returns a list of email addresses.
 
@@ -255,7 +255,7 @@ Error: foo.bar is not a valid slug
 
 ## SlugListParamType
 
-Signature: `SlugListParamType(separator: str = ',')`
+Signature: `SlugListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Validates and returns a list of slugs.
 

--- a/docs/usage/miscellaneous.md
+++ b/docs/usage/miscellaneous.md
@@ -59,7 +59,7 @@ Error: 00:00:00:00:00 is not a valid mac address
 
 ## MacAddressListParamType
 
-Signature: `MacAddressListParamType(separator: str = ',')`
+Signature: `MacAddressListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Validates and returns a list of mac addresses
 
@@ -88,7 +88,7 @@ Error: These items are not mac addresses: ['foo']
 
 ## StringListParamType
 
-Signature: `StringListParamType(separator: str = ',')`
+Signature: `StringListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts given string to a list of strings.
 
@@ -115,7 +115,7 @@ Your list of preferred fruits:
 
 ## UUIDListParamType
 
-Signature: `UUIDListParamType(separator: str = ',')`
+Signature: `UUIDListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `uuid.UUID` objects.
 
@@ -143,7 +143,7 @@ Error: These items are not uuid: ['452-45', '410']
 
 ## DateTimeParamListType
 
-Signature: `DateTimeParamListType(separator: str = ',', formats: List[str] = None)`
+Signature: `DateTimeParamListType(separator: str = ',', ignore_empty: bool = False, formats: List[str] = None)`
 
 Converts string to a list of `datetime.datetime` objects. Unlike other classes, this class has a `formats` parameter
 that is exactly the same as the one passed to the constructor of `click.DateTime` class.

--- a/docs/usage/network.md
+++ b/docs/usage/network.md
@@ -39,7 +39,7 @@ Error: 12.45 is not a valid ip address
 
 ## IpAddressListParamType
 
-Signature: `IpAddressListParamType(separator: str = ',')`
+Signature: `IpAddressListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `ipaddress.IPv4Address` or `ipaddress.IPv6Address` objects.
 
@@ -123,7 +123,7 @@ Error: 127.0.0.0 is not in the valid range of 127.0.0.1 to 127.0.0.125.
 
 ## Ipv4AddressListParamType
 
-Signature: `Ipv4AddressListParamType(separator: str = ',')`
+Signature: `Ipv4AddressListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `ipaddress.IPv4Address` objects.
 
@@ -207,7 +207,7 @@ Error: 2001:dc00::9 is not in the valid range of 2001:db00::1 to 2001:dbff:ffff:
 
 ## Ipv6AddressListParamType
 
-Signature: `Ipv6AddressListParamType(separator: str = ',')`
+Signature: `Ipv6AddressListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `ipaddress.IPv6Address` objects.
 
@@ -261,7 +261,7 @@ Error: 1245 is not a valid ip network
 
 ## IpNetworkListParamType
 
-Signature: `IpNetworkListParamType(separator: str = ',')`
+Signature: `IpNetworkListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `ipaddress.IPv4Network` or `ipaddress.IPv6Network` objects.
 
@@ -312,7 +312,7 @@ Error: 2001:db00::/24 is not a valid ipv4 network
 
 ## Ipv4NetworkListParamType
 
-Signature: `Ipv4NetworkListParamType(separator: str = ',')`
+Signature: `Ipv4NetworkListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `ipaddress.IPv4Network` objects.
 
@@ -363,7 +363,7 @@ Error: 192.168.1.0/24 is not a valid ipv6 network
 
 ## Ipv6NetworkListParamType
 
-Signature: `Ipv6NetworkListParamType(separator: str = ',')`
+Signature: `Ipv6NetworkListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts string to a list of `ipaddress.IPv6Network` objects.
 

--- a/docs/usage/numeric.md
+++ b/docs/usage/numeric.md
@@ -69,7 +69,7 @@ Error: 1/100 is not in the valid range of 1/10 to 1.
 
 ## FractionListParamType
 
-Signature: `FractionListParamType(separator: str = ',')`
+Signature: `FractionListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts a string to a list of `fractions.Fraction` objects.
 
@@ -157,7 +157,7 @@ Error: 0.3 is not in the valid range of 0.5 to 1.5.
 
 ## DecimalListParamType
 
-Signature: `DecimalListParamType(separator: str = ',')`
+Signature: `DecimalListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts a string to a list of `decimal.Decimal` objects.
 
@@ -213,7 +213,7 @@ You will notice in the last example that space is not allowed when specifying th
 
 ## ComplexListParamType
 
-Signature: `ComplexListParamType(separator: str = ',')`
+Signature: `ComplexListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts a string to a list of `complex` values.
 
@@ -243,7 +243,7 @@ Error: These items are not complex values: ['1/2']
 
 ## IntListParamType
 
-Signature: `IntListParamType(separator: str = ',')`
+Signature: `IntListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts a string to a list of integers.
 
@@ -271,7 +271,7 @@ Error: These items are not integers: ['4.5']
 
 ## FloatListParamType
 
-Signature: `FloatListParamType(separator: str = ',')`
+Signature: `FloatListParamType(separator: str = ',', ignore_empty: bool = False)`
 
 Converts a string to a list of floating point values.
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -185,3 +185,14 @@ class TestListParamType:
         # after the first call, all subsequent calls will have the converted value as first argument
         assert base_list._convert_called
         assert values == base_list.convert(values, None, None)
+
+    @pytest.mark.parametrize('param_type', [
+        click.INT, click.FLOAT, click.STRING, FRACTION, COMPLEX
+    ])
+    def test_should_return_empty_list_with_ignore_empty_string(self, param_type):
+        base_list = ListParamType(param_type=param_type, ignore_empty=True)
+        assert base_list.convert("", None, None) == []
+
+    def test_should_return_non_empty_list_without_ignore_empty_string(self):
+        base_list = ListParamType(param_type=click.STRING)
+        assert base_list.convert("", None, None) == ['']

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -124,3 +124,12 @@ def test_should_print_correct_output_when_giving_correct_option_for_list_types(r
     result = runner.invoke(cli, ['-v', expression])
 
     assert_equals_output(0, expected_output, result)
+
+
+@pytest.mark.parametrize("param_type", [
+    DomainListParamType, PublicUrlListParamType, UrlListParamType, EmailListParamType, SlugListParamType
+])
+def test_domain_list_param_types_ignore_empty_string(param_type):
+    domain_list_type = param_type(ignore_empty=True)
+
+    assert domain_list_type.convert("", None, None) == []

--- a/tests/test_miscellaneous.py
+++ b/tests/test_miscellaneous.py
@@ -107,6 +107,15 @@ def test_should_print_correct_output_when_giving_correct_option_for_list_types(r
     assert_equals_output(0, expected_output, result)
 
 
+@pytest.mark.parametrize("param_type", [
+    StringListParamType, MacAddressListParamType, UUIDListParamType, DateTimeListParamType
+])
+def test_miscellaneous_list_param_types_ignore_empty_string(param_type):
+    misc_list_type = param_type(ignore_empty=True)
+
+    assert misc_list_type.convert("", None, None) == []
+
+
 class TestJsonParamType:
     """Tests JsonParamType specific cases"""
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -182,3 +182,13 @@ def test_should_print_correct_output_when_giving_correct_option_for_list_types(r
     result = runner.invoke(cli, ['-v', expression])
 
     assert_equals_output(0, expected_output, result)
+
+
+@pytest.mark.parametrize("param_type", [
+    IpAddressListParamType, Ipv4AddressListParamType, Ipv6AddressListParamType, IpNetworkListParamType,
+    Ipv4NetworkListParamType, Ipv6NetworkListParamType
+])
+def test_network_list_param_types_ignore_empty_string(param_type):
+    network_list_type = param_type(ignore_empty=True)
+
+    assert network_list_type.convert("", None, None) == []

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -136,3 +136,12 @@ def test_should_print_correct_output_when_giving_correct_option_for_list_types(r
     result = runner.invoke(cli, ['-v', expression])
 
     assert_equals_output(0, expected_output, result)
+
+
+@pytest.mark.parametrize("param_type", [
+    IntListParamType, FloatListParamType, ComplexListParamType, DecimalListParamType, FractionListParamType
+])
+def test_numeric_list_param_types_ignore_empty_string(param_type):
+    numeric_list_type = param_type(ignore_empty=True)
+
+    assert numeric_list_type.convert("", None, None) == []


### PR DESCRIPTION
Fixes #13 

As suggested in the linked issue, one can now choose list parameter types to treat empty strings as empty list.
This is a quite common use case that should be treated.