### PR TITLE
Rename UnionParamType to FirstOf, change implementation to take positional args, fully typehint, more verbose errors, optional return tuple with param used for conversion.

### DIFF
--- a/click_params/__init__.py
+++ b/click_params/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
 
     # miscellaneous
     'JSON', 'MAC_ADDRESS', 'ChoiceListParamType', 'StringListParamType', 'MacAddressListParamType', 'UUIDListParamType',
-    'DateTimeListParamType', 'UnionParamType',
+    'DateTimeListParamType', 'FirstOf',
 
     # network
     'IP_ADDRESS', 'IPV6_ADDRESS', 'IPV4_ADDRESS', 'IP_NETWORK', 'IPV4_NETWORK', 'IPV6_NETWORK', 'Ipv4AddressRange',

--- a/click_params/__init__.py
+++ b/click_params/__init__.py
@@ -7,7 +7,7 @@ from .domain import (
 )
 from .miscellaneous import (
     JSON, MAC_ADDRESS, StringListParamType, ChoiceListParamType, MacAddressListParamType, UUIDListParamType,
-    DateTimeListParamType, UnionParamType
+    DateTimeListParamType, FirstOf
 )
 from .network import (
     IP_ADDRESS, IPV4_ADDRESS, IPV6_ADDRESS, IP_NETWORK, IPV4_NETWORK, IPV6_NETWORK, Ipv4AddressRange, Ipv6AddressRange,

--- a/click_params/miscellaneous.py
+++ b/click_params/miscellaneous.py
@@ -1,12 +1,12 @@
 """Parameter types that do not fit into other modules"""
 import json
+from textwrap import indent
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 import click
 from validators import mac_address
 
 from .base import ValidatorParamType, ListParamType, CustomParamType
-
 
 class JsonParamType(click.ParamType):
     name = 'json'
@@ -105,7 +105,7 @@ class FirstOf(CustomParamType):
             "All possible options exhausted without any successful conversion:\n - "
             + "\n - ".join(
                 [
-                    f"{getattr(f[0], 'name', f[0].__class__.__name__).upper()}: {f[1]}"
+                    indent(f"{getattr(f[0], 'name', f[0].__class__.__name__).upper()}: {f[1]}", " ")
                     for f in fails
                 ]
             )

--- a/click_params/miscellaneous.py
+++ b/click_params/miscellaneous.py
@@ -107,7 +107,11 @@ class FirstOf(CustomParamType):
             "All possible options exhausted without any successful conversion:\n - "
             + "\n - ".join(
                 [
-                    indent(f"{getattr(f[0], 'name', f[0].__class__.__name__).upper()}: {f[1]}", " ")
+                    indent(
+                        f"{getattr(f[0], 'name', f[0].__class__.__name__).upper()}:"
+                        f" {f[1]}",
+                        " ",
+                    )
                     for f in fails
                 ]
             )

--- a/click_params/miscellaneous.py
+++ b/click_params/miscellaneous.py
@@ -8,6 +8,7 @@ from validators import mac_address
 
 from .base import ValidatorParamType, ListParamType, CustomParamType
 
+
 class JsonParamType(click.ParamType):
     name = 'json'
 
@@ -86,7 +87,8 @@ class FirstOf(CustomParamType):
             if name:
                 self.name = name
             else:
-                # Set name to union representation of individual params. Using bitwise-or operator as thats used by python sets.
+                # Set name to union representation of individual params.
+                # Using pipe | as thats used by python sets for union.
                 self.name = "(" + " | ".join(p.name for p in self.param_types) + ")"
 
     def convert(

--- a/click_params/miscellaneous.py
+++ b/click_params/miscellaneous.py
@@ -79,18 +79,21 @@ class DateTimeListParamType(ListParamType):
 
 
 class FirstOf(click.ParamType):
-    def __init__(self, *args: click.ParamType):
-        self.params = args
+    def __init__(self, *param_types: click.ParamType, name: Optional[str] = None):
+        self.param_types = param_types
         # Set name to union representation of individual params if not already set (by subclassing).
         if not getattr(self, "name", None):
-            self.name = "(" + " | ".join(p.name for p in self.params) + ")"
+            if name:
+                self.name = name
+            else:
+                self.name = "(" + " | ".join(p.name for p in self.param_types) + ")"
 
     def convert(
         self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]
     ) -> Any:
         # Collect failure messages to emit later.
         fails: List[Tuple[click.ParamType, str]] = []
-        for par in self.params:
+        for par in self.param_types:
             try:
                 return (par, par.convert(value, param, ctx))
             except click.BadParameter as e:

--- a/docs/usage/miscellaneous.md
+++ b/docs/usage/miscellaneous.md
@@ -210,13 +210,19 @@ formats.
 
 ## FirstOf
 
-Signature: `FirstOf(*param_types: click.ParamType)`
+Signature: `FirstOf(*param_types: click.ParamType, name: Optional[str] = None, return_param: bool = False)`
 
 Allows an option or an argument to accept at least two kinds of types.
 
+- `name` is used as a custom name. If none is specified, a set union `(param1 | param2)` is used as name.
+- with `return_param` the FirstOf will return the parameter used for conversion alongside the result, as a tuple `(param, value)`.
+This allows for logic in a command to check which conversion was used in case there are differences in handling,
+especially differences in the param_types return types.
+
+
 ````python
 import click
-from click_params import UnionParamType
+from click_params import FirstOf
 
 @click.command()
 @click.option('-j', '--jobs', type=FirstOf(click.Choice(['half', 'all']), click.INT, name="cores number"))
@@ -233,14 +239,16 @@ $ python cli.py -j all
 Running on all cores
 
 $ python cli.py -j 2.5
-Error: 2.5 is not a valid cores number
+Error: Invalid value for '-j' / '--jobs': All possible options exhausted without any successful conversion:
+ - CHOICE: '2.5' is not one of 'half', 'all'.
+ - INTEGER: '2.5' is not a valid integer.
 
 $ python cli.py -j third
-Error: third is not a valid cores number
+Error: Invalid value for '-j' / '--jobs': All possible options exhausted without any successful conversion:
+ - CHOICE: 'third' is not one of 'half', 'all'.
+ - INTEGER: 'third' is not a valid integer.
 ````
 
 Two remarks compared to the last script.
 
 - The order of parameter types in the union is the order click will try to parse the value.
-- In the last two examples click was unable to parse because they were neither an integer nor a string from allowed 
-choices.

--- a/docs/usage/miscellaneous.md
+++ b/docs/usage/miscellaneous.md
@@ -208,9 +208,9 @@ has a whitespace, therefore the separator helps to split properly.
 `click.DateTime`. If you want this datetime to be accepted, you need to provide a `formats` argument with the appropriate
 formats.
 
-## UnionParamType
+## FirstOf
 
-Signature: `UnionParamType(param_types: Sequence[click.ParamType], name: str = None)`
+Signature: `FirstOf(*param_types: click.ParamType)`
 
 Allows an option or an argument to accept at least two kinds of types.
 
@@ -219,7 +219,7 @@ import click
 from click_params import UnionParamType
 
 @click.command()
-@click.option('-j', '--jobs', type=UnionParamType([click.Choice(['half', 'all']), click.INT], name="cores number"))
+@click.option('-j', '--jobs', type=FirstOf(click.Choice(['half', 'all']), click.INT, name="cores number"))
 def cli(jobs):
     click.echo('Running on {jobs} cores!'.format(jobs=jobs))
     ...

--- a/tests/test_miscellaneous.py
+++ b/tests/test_miscellaneous.py
@@ -177,5 +177,5 @@ class TestFirstOf:
     ])
     def test_should_parse_expression_unsuccessfully(self, expression, param_types):
         union_type = FirstOf(*param_types)
-        with pytest.raises(click.BadParameter, match=r'.*\n - '.join(p.name.upper() for p in param_types)) as e:
+        with pytest.raises(click.BadParameter, match=r'.*\n -  '.join(p.name.upper() for p in param_types)) as e:
             union_type.convert(expression, None, None)


### PR DESCRIPTION
This PR does a few things with the UnionParamType which i accidentally re-implemented in a project of mine. I fully understand if the changes to the API/usage are not wanted, though personally i find they increase readability a lot.

- Renames it to `FirstOf` which is more in line with click names like `Choice`
- Changes argument to *param_types, which looks cleaner in user code: `FirstOf(click.INT, click.FLOAT)`
- In case no name is given, use a python set union as a name: `(a | b)`
- Fully typehints it (passes mypy and strict pyright), only issue is the Any return on convert which isn't resolvable without major changes to click and click_params
- Makes errors more verbose by passing out the individual errors of the ParamTypes passed in. This also works with nested FirstOf
- Optionally return the ParamType instance/type used for the conversion, for use cases where the conversion used determines some functionality of the command.

Example error of a nested FirstOf (no names given, therefore default union name used):
```
Error: Invalid value for '-j': All possible options exhausted without any successful conversion:
 -  (INTEGER | (INTEGER | FLOAT)): All possible options exhausted without any successful conversion:
  -  INTEGER: 'asdas' is not a valid integer.
  -  (INTEGER | FLOAT): All possible options exhausted without any successful conversion:
   -  INTEGER: 'asdas' is not a valid integer.
   -  FLOAT: 'asdas' is not a valid float.
 -  INTEGER: 'asdas' is not a valid integer.
```

Checklist:
- [x] Changed functionality
- [x] Updated tests which pass.
- [x] Updated relevant docs.